### PR TITLE
Corrected The FK Restraint Names

### DIFF
--- a/BangazonApi/Bangazon_Drop_Delete_Queries.sql
+++ b/BangazonApi/Bangazon_Drop_Delete_Queries.sql
@@ -1,3 +1,5 @@
+USE Bangazon;
+
 DELETE FROM Departments;
 DELETE FROM Employees;
 DELETE FROM Computers;
@@ -15,21 +17,18 @@ DELETE FROM ProductOrders;
 
 
 ALTER TABLE Employees DROP CONSTRAINT [FK_Department_Employees];
-ALTER TABLE EmployeeComputers DROP CONSTRAINT [FK_EmployeeId];
-ALTER TABLE EmployeeComputers DROP CONSTRAINT [FK_ComputerId];
-ALTER TABLE EmployeeTrainingRegiments DROP CONSTRAINT [FK_EmployeeId];
-ALTER TABLE EmployeeTrainingRegiments DROP CONSTRAINT [FK_ComputerId];
+ALTER TABLE EmployeeComputers DROP CONSTRAINT [FK_EmployeeComputer];
+ALTER TABLE EmployeeComputers DROP CONSTRAINT [FK_ComputerEmployee];
+ALTER TABLE EmployeeTrainingRegiments DROP CONSTRAINT [FK_EmployeeTraining];
+ALTER TABLE EmployeeTrainingRegiments DROP CONSTRAINT [FK_TrainingEmployees];
 ALTER TABLE Products DROP CONSTRAINT [FK_ProductTypeId];
 ALTER TABLE Products DROP CONSTRAINT [FK_CustomerId];
-ALTER TABLE Payments DROP CONSTRAINT [FK_CustomerId];
+ALTER TABLE Payments DROP CONSTRAINT [FK_CustomerPayment];
 ALTER TABLE Orders DROP CONSTRAINT [FK_PaymentId];
-ALTER TABLE Orders DROP CONSTRAINT [FK_CustomerId];
+ALTER TABLE Orders DROP CONSTRAINT [FK_CustomerOrders];
 ALTER TABLE ProductOrders DROP CONSTRAINT [FK_OrderId];
 ALTER TABLE ProductOrders DROP CONSTRAINT [FK_ProductId];
-ALTER TABLE Instructor DROP CONSTRAINT [FK_Cohort];
-ALTER TABLE Instructor DROP CONSTRAINT [FK_Cohort];
-ALTER TABLE Instructor DROP CONSTRAINT [FK_Cohort];
-ALTER TABLE Instructor DROP CONSTRAINT [FK_Cohort];
+
 
 
 DROP TABLE IF EXISTS Departments;

--- a/BangazonApi/Bangazon_Drop_Delete_Queries.sql
+++ b/BangazonApi/Bangazon_Drop_Delete_Queries.sql
@@ -1,0 +1,47 @@
+DELETE FROM Departments;
+DELETE FROM Employees;
+DELETE FROM Computers;
+DELETE FROM TrainingPrograms;
+DELETE FROM EmployeeComputers;
+DELETE FROM EmployeeTrainingRegiments;
+DELETE FROM Customers;
+DELETE FROM ProductTypes;
+DELETE FROM Products;
+DELETE FROM Payments;
+DELETE FROM Orders;
+DELETE FROM ProductOrders;
+
+
+
+
+ALTER TABLE Employees DROP CONSTRAINT [FK_Department_Employees];
+ALTER TABLE EmployeeComputers DROP CONSTRAINT [FK_EmployeeId];
+ALTER TABLE EmployeeComputers DROP CONSTRAINT [FK_ComputerId];
+ALTER TABLE EmployeeTrainingRegiments DROP CONSTRAINT [FK_EmployeeId];
+ALTER TABLE EmployeeTrainingRegiments DROP CONSTRAINT [FK_ComputerId];
+ALTER TABLE Products DROP CONSTRAINT [FK_ProductTypeId];
+ALTER TABLE Products DROP CONSTRAINT [FK_CustomerId];
+ALTER TABLE Payments DROP CONSTRAINT [FK_CustomerId];
+ALTER TABLE Orders DROP CONSTRAINT [FK_PaymentId];
+ALTER TABLE Orders DROP CONSTRAINT [FK_CustomerId];
+ALTER TABLE ProductOrders DROP CONSTRAINT [FK_OrderId];
+ALTER TABLE ProductOrders DROP CONSTRAINT [FK_ProductId];
+ALTER TABLE Instructor DROP CONSTRAINT [FK_Cohort];
+ALTER TABLE Instructor DROP CONSTRAINT [FK_Cohort];
+ALTER TABLE Instructor DROP CONSTRAINT [FK_Cohort];
+ALTER TABLE Instructor DROP CONSTRAINT [FK_Cohort];
+
+
+DROP TABLE IF EXISTS Departments;
+DROP TABLE IF EXISTS Employees;
+DROP TABLE IF EXISTS Computers;
+DROP TABLE IF EXISTS TrainingPrograms;
+DROP TABLE IF EXISTS EmployeeComputers;
+DROP TABLE IF EXISTS EmployeeTrainingRegiments;
+DROP TABLE IF EXISTS Customers;
+DROP TABLE IF EXISTS ProductTypes;
+DROP TABLE IF EXISTS Products;
+DROP TABLE IF EXISTS Payments;
+DROP TABLE IF EXISTS Orders;
+DROP TABLE IF EXISTS ProductOrders;
+

--- a/BangazonApi/Bangazon_Tables.sql
+++ b/BangazonApi/Bangazon_Tables.sql
@@ -80,7 +80,7 @@ CREATE TABLE Products (
 	ProductTypeId INTEGER NOT NULL,
 	CustomerId INTEGER NOT NULL,
     CONSTRAINT FK_ProductTypeId FOREIGN KEY(ProductTypeId) REFERENCES ProductTypes(Id),
-    CONSTRAINT FK_CustomerProduct FOREIGN KEY(CustomerId) REFERENCES Customers(Id)
+    CONSTRAINT FK_CustomerId FOREIGN KEY(CustomerId) REFERENCES Customers(Id)
 
 );
 

--- a/BangazonApi/Bangazon_Tables.sql
+++ b/BangazonApi/Bangazon_Tables.sql
@@ -1,0 +1,111 @@
+
+
+-- Internal Table
+
+CREATE TABLE Departments (
+    Id	INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    Name varchar(80) NOT NULL UNIQUE,
+	ExpenseBudget FLOAT NOT NULL
+
+);
+
+CREATE TABLE Employees (
+    Id	INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    FirstName	VARCHAR(80) NOT NULL,
+    LastName	VARCHAR(80) NOT NULL,
+    Supervisor BIT NOT NULL, 
+    DepartmentId	INTEGER NOT NULL,
+    CONSTRAINT FK_Department_Employees FOREIGN KEY(DepartmentId) REFERENCES Departments(Id)
+);
+
+CREATE TABLE Computers (
+    Id	INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    PurchaseDate	DATE NOT NULL,
+    DecommisionDate DATE,
+	Make VARCHAR(80) NOT NULL,
+	Model VARCHAR(80) NOT NULL
+);
+
+
+CREATE TABLE TrainingPrograms (
+    Id	integer NOT NULL PRIMARY KEY IDENTITY,
+    ProgramName	varchar(80) NOT NULL,
+    StartDate	DATE NOT NULL,
+    EmdDate	DATE,
+    MaxAttendees integer NOT NULL
+);
+
+CREATE TABLE EmployeeComputers (
+    Id	        INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    EmployeeId	INTEGER NOT NULL,
+    ComputerId 	INTEGER NOT NULL,
+    AssignedDate DATE NOT NULL,
+    CONSTRAINT FK_EmployeeId FOREIGN KEY(EmployeeId) REFERENCES Employees(Id),
+    CONSTRAINT FK_ComputerId FOREIGN KEY(ComputerId) REFERENCES Computers(Id)
+
+);
+
+CREATE TABLE EmployeeTrainingRegiments (
+    Id	        INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    EmployeeId	INTEGER NOT NULL,
+    ComputerId 	INTEGER NOT NULL,
+    CONSTRAINT FK_EmployeeId FOREIGN KEY(EmployeeId) REFERENCES Employees(Id),
+    CONSTRAINT FK_ComputerId FOREIGN KEY(ComputerId) REFERENCES Computers(Id)
+
+);
+
+-- External Table
+
+CREATE TABLE Customers (
+    Id	        INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    FirstName	VARCHAR(80) NOT NULL,
+    LastName 	VARCHAR(80) NOT NULL,
+    AccountCreationDate DATE NOT NULL,
+	LastLoginDate DATE NOT NULL
+
+);
+
+CREATE TABLE ProductTypes (
+    Id	        INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    ProductType	VARCHAR(80) NOT NULL,
+   
+);
+
+CREATE TABLE Products (
+    Id	        INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    Title	VARCHAR(80) NOT NULL,
+    Price 	FLOAT NOT NULL,
+    Description VARCHAR(80) NOT NULL,
+	Quantity INTEGER NOT NULL,
+	ProductTypeId INTEGER NOT NULL,
+	CustomerId INTEGER NOT NULL,
+    CONSTRAINT FK_ProductTypeId FOREIGN KEY(ProductTypeId) REFERENCES ProductTypes(Id),
+    CONSTRAINT FK_CustomerId FOREIGN KEY(CustomerId) REFERENCES Customers(Id)
+
+);
+
+CREATE TABLE Payments (
+    Id	        INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    TypeAccountNumber	INTEGER NOT NULL,
+    Type 	   VARCHAR(80) NOT NULL,
+    BillingAddress VARCHAR(100) NOT NULL,
+	CustomerId INTEGER NOT NULL,
+	CONSTRAINT FK_CustomerId FOREIGN KEY(CustomerId) REFERENCES Customers(Id),
+);
+
+CREATE TABLE Orders (
+    Id	        INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    PaymentId	INTEGER NOT NULL,
+    CustomerId 	INTEGER NOT NULL,
+	CONSTRAINT FK_PaymentId FOREIGN KEY(PaymentId) REFERENCES Payments(Id),
+	CONSTRAINT FK_CustomerId FOREIGN KEY(CustomerId) REFERENCES Customers(Id)
+);
+
+CREATE TABLE ProductOrders (
+    Id	        INTEGER NOT NULL PRIMARY KEY IDENTITY,
+    OrderId	    INTEGER NOT NULL,
+    ProductId 	INTEGER NOT NULL,
+	CONSTRAINT FK_OrderId FOREIGN KEY(OrderId) REFERENCES Orders(Id),
+	CONSTRAINT FK_ProductId FOREIGN KEY(ProductId) REFERENCES Products(Id)
+	
+);

--- a/BangazonApi/Bangazon_Tables.sql
+++ b/BangazonApi/Bangazon_Tables.sql
@@ -40,17 +40,17 @@ CREATE TABLE EmployeeComputers (
     EmployeeId	INTEGER NOT NULL,
     ComputerId 	INTEGER NOT NULL,
     AssignedDate DATE NOT NULL,
-    CONSTRAINT FK_EmployeeId FOREIGN KEY(EmployeeId) REFERENCES Employees(Id),
-    CONSTRAINT FK_ComputerId FOREIGN KEY(ComputerId) REFERENCES Computers(Id)
+    CONSTRAINT FK_EmployeeComputer FOREIGN KEY(EmployeeId) REFERENCES Employees(Id),
+    CONSTRAINT FK_ComputerEmployee FOREIGN KEY(ComputerId) REFERENCES Computers(Id)
 
 );
 
 CREATE TABLE EmployeeTrainingRegiments (
     Id	        INTEGER NOT NULL PRIMARY KEY IDENTITY,
     EmployeeId	INTEGER NOT NULL,
-    ComputerId 	INTEGER NOT NULL,
-    CONSTRAINT FK_EmployeeId FOREIGN KEY(EmployeeId) REFERENCES Employees(Id),
-    CONSTRAINT FK_ComputerId FOREIGN KEY(ComputerId) REFERENCES Computers(Id)
+    EmployeeTrainingId 	INTEGER NOT NULL,
+    CONSTRAINT FK_EmployeeTraining FOREIGN KEY(EmployeeId) REFERENCES Employees(Id),
+    CONSTRAINT FK_TrainingEmployees FOREIGN KEY(EmployeeTrainingId) REFERENCES TrainingPrograms(Id)
 
 );
 
@@ -80,7 +80,7 @@ CREATE TABLE Products (
 	ProductTypeId INTEGER NOT NULL,
 	CustomerId INTEGER NOT NULL,
     CONSTRAINT FK_ProductTypeId FOREIGN KEY(ProductTypeId) REFERENCES ProductTypes(Id),
-    CONSTRAINT FK_CustomerId FOREIGN KEY(CustomerId) REFERENCES Customers(Id)
+    CONSTRAINT FK_CustomerProduct FOREIGN KEY(CustomerId) REFERENCES Customers(Id)
 
 );
 
@@ -90,7 +90,7 @@ CREATE TABLE Payments (
     Type 	   VARCHAR(80) NOT NULL,
     BillingAddress VARCHAR(100) NOT NULL,
 	CustomerId INTEGER NOT NULL,
-	CONSTRAINT FK_CustomerId FOREIGN KEY(CustomerId) REFERENCES Customers(Id),
+	CONSTRAINT FK_CustomerPayment FOREIGN KEY(CustomerId) REFERENCES Customers(Id),
 );
 
 CREATE TABLE Orders (
@@ -98,7 +98,7 @@ CREATE TABLE Orders (
     PaymentId	INTEGER NOT NULL,
     CustomerId 	INTEGER NOT NULL,
 	CONSTRAINT FK_PaymentId FOREIGN KEY(PaymentId) REFERENCES Payments(Id),
-	CONSTRAINT FK_CustomerId FOREIGN KEY(CustomerId) REFERENCES Customers(Id)
+	CONSTRAINT FK_CustomerOrders FOREIGN KEY(CustomerId) REFERENCES Customers(Id)
 );
 
 CREATE TABLE ProductOrders (


### PR DESCRIPTION
# Pull Request---Ultra-Mules: Bangazon

### Issue Reference
The names of the Foreign Key Restraints were not matching the updated Foreign Keys in the Bangazon_Tables file.

### Description of Changes
I changed each of the Foreign Key names under the Alter Table list on the Bangazon Drop_Delete Queries file , to match the names we updated in the Bangazon_Tables file. 
- [ ] Clarity

- [ ] rationale of structure  

- [ ] Provide Context to paint mental picture 

### Steps to Test

Open these two files in SQL Server Console and Execute. 
1. Bangazon_Drop_Delete_Queries
2. Bangazon_Tables

### System Configuration 

- [ ] 3rd Party Library 

- [ ] Command line utilities 

- [ ] UI Steps


### Will Review (Minimum: 2 Approvals)
Jacob Henderson, Aaron Miller
### Link to Ticket of Feature 

